### PR TITLE
ci: add GitHub Actions deploy workflows + branch/deploy strategy docs

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,51 @@
+name: Deploy Functions — DEV
+
+# Auto-deploys the Cloud Functions to the DEV project (g-play-dd31d) whenever
+# development changes. Can also be run manually from the Actions tab.
+on:
+  push:
+    branches: [development]
+    paths:
+      - "functions/**"
+      - "firebase.json"
+      - ".firebaserc"
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+
+      - name: Lint
+        working-directory: functions
+        run: npm run lint
+
+      - name: Write functions/.env (DEV secrets)
+        working-directory: functions
+        run: |
+          cat > .env <<'EOF'
+          STRIPE_SECRET=${{ secrets.DEV_STRIPE_SECRET }}
+          STRIPE_WEBHOOK_SECRET=${{ secrets.DEV_STRIPE_WEBHOOK_SECRET }}
+          APPLE_SHARED_SECRET=${{ secrets.DEV_APPLE_SHARED_SECRET }}
+          EOF
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.DEV_FIREBASE_SA_KEY }}
+
+      - name: Deploy to DEV
+        run: npx firebase-tools deploy --only functions --project dev --non-interactive

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,52 @@
+name: Deploy Functions — PROD
+
+# Auto-deploys the Cloud Functions to the PROD project (g-play-dev-e4c4c) whenever
+# main changes. Can also be run manually from the Actions tab (used for the first
+# controlled cutover — see docs/DEPLOYMENT.md).
+on:
+  push:
+    branches: [main]
+    paths:
+      - "functions/**"
+      - "firebase.json"
+      - ".firebaserc"
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+
+      - name: Lint
+        working-directory: functions
+        run: npm run lint
+
+      - name: Write functions/.env (PROD secrets)
+        working-directory: functions
+        run: |
+          cat > .env <<'EOF'
+          STRIPE_SECRET=${{ secrets.PROD_STRIPE_SECRET }}
+          STRIPE_WEBHOOK_SECRET=${{ secrets.PROD_STRIPE_WEBHOOK_SECRET }}
+          APPLE_SHARED_SECRET=${{ secrets.PROD_APPLE_SHARED_SECRET }}
+          EOF
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.PROD_FIREBASE_SA_KEY }}
+
+      - name: Deploy to PROD
+        run: npx firebase-tools deploy --only functions --project prod --non-interactive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,13 @@ firebase functions:log                       # tail logs (npm run logs)
   [docs/gplay-dev.postman_collection.json](docs/gplay-dev.postman_collection.json)
   (read-only requests; `checkEmail` is the best health check — a clean `200` proves
   `admin.auth()` + Firestore work).
-- **A bare deploy ships to DEV.** [.firebaserc](.firebaserc) aliases `default` and `dev` →
-  `g-play-dd31d` (the **DEV** project) and `prod` → `g-play-dev-e4c4c` (the **PROD** project,
-  despite its `-dev-` id). Deploy to prod explicitly with `firebase deploy --only functions
-  --project prod`; verify the active target with `firebase use` first.
+- **Deploys are CI/CD-driven.** Merging to `development` auto-deploys to **DEV**
+  (`g-play-dd31d`); merging to `main` auto-deploys to **PROD** (`g-play-dev-e4c4c`) — via
+  `.github/workflows/deploy-{dev,prod}.yml`. Feature branches → PR into `development`; promote
+  with a `development` → `main` PR. Full strategy + first-prod cutover in
+  [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md). Manual fallback (verify target with `firebase use`
+  first): [.firebaserc](.firebaserc) aliases `default`/`dev` → DEV and `prod` → PROD, so
+  `firebase deploy --only functions` hits DEV and `--project prod` hits PROD.
 - Node runtime is pinned to **22** (`functions/package.json` engines + repo-root
   [.nvmrc](.nvmrc)) — the newest runtime Firebase-managed Cloud Functions supports (Node 24
   is *not* deployable here). No region is set, so functions deploy to the default

--- a/README.md
+++ b/README.md
@@ -83,12 +83,43 @@ firebase emulators:start --only functions   # levanta las functions localmente
 firebase functions:shell                     # shell interactivo para invocarlas
 ```
 
-## Deploy
+## Estrategia de branches y despliegue
 
-> El deploy ejecuta `npm run lint` (ESLint) como hook de *predeploy*; si el lint falla, el
-> deploy se aborta. Corre `npm run lint` antes para detectar errores.
+El despliegue es **automático vía GitHub Actions**: cada branch de larga vida está atada a un
+entorno y al hacer merge se dispara el deploy correspondiente.
+
+```
+feature/* ──PR──▶ development ──(merge)──▶ GitHub Action ──▶ DEV  (g-play-dd31d)
+                       │
+                       └──PR "release"──▶ main ──(merge)──▶ GitHub Action ──▶ PROD (g-play-dev-e4c4c)
+```
+
+| Branch        | Entorno                    | Workflow                             |
+| ------------- | -------------------------- | ------------------------------------ |
+| `development` | **DEV** (`g-play-dd31d`)   | `.github/workflows/deploy-dev.yml`   |
+| `main`        | **PROD** (`g-play-dev-e4c4c`) | `.github/workflows/deploy-prod.yml` |
+
+Flujo de trabajo:
+1. Crea un branch `feature/*` (o `fix/*`, `chore/*`) **desde `development`**.
+2. Abre un PR hacia `development`. Al hacer merge se despliega a **DEV** automáticamente.
+3. Prueba en DEV (ver *smoke tests* más abajo y la app).
+4. Para llevar a producción: abre un PR de **`development` → `main`**. El merge despliega a **PROD**.
+
+Reglas: **no hagas push directo** a `development` ni a `main` (protégelas en GitHub);
+`main` siempre refleja lo que está en producción.
+
+> 📖 Configuración detallada (service accounts, secrets de GitHub, protección de branches y el
+> **primer despliegue a PROD** — que es una migración especial) en
+> [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md). **Léelo antes del primer deploy a producción.**
+
+## Deploy manual (fallback)
+
+Solo si CI no está disponible. El deploy ejecuta `npm run lint` (ESLint) como hook de
+*predeploy*; si el lint falla, el deploy se aborta.
 
 ```bash
+nvm use   # Node 22
+
 # Todas las functions (al DEV, que es el default)
 firebase deploy --only functions
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,98 @@
+# Deployment guide (branch strategy & CI/CD)
+
+Operational reference for deploying the GPlay Cloud Functions. For the quick overview see the
+**"Estrategia de branches y despliegue"** section in [../README.md](../README.md).
+
+## Branch → environment model
+
+```
+feature/* ──PR──▶ development ──(push/merge)──▶ GitHub Action ──▶ DEV  (g-play-dd31d)
+                       │
+                       └──PR "release"──▶ main ──(push/merge)──▶ GitHub Action ──▶ PROD (g-play-dev-e4c4c)
+```
+
+| Branch        | Firebase project      | Alias  | Deploys via                         |
+| ------------- | --------------------- | ------ | ----------------------------------- |
+| `development` | `g-play-dd31d` (DEV)  | `dev`  | `.github/workflows/deploy-dev.yml`  |
+| `main`        | `g-play-dev-e4c4c` (PROD) | `prod` | `.github/workflows/deploy-prod.yml` |
+
+Rules:
+- All work happens on short-lived `feature/*` (or `chore/*`, `fix/*`) branches off
+  `development`, merged back via PR.
+- Promote to production with a PR from `development` → `main`. Merging it triggers the PROD deploy.
+- **No direct pushes** to `development` or `main` (enforce with branch protection, below).
+- `main` always reflects what is live in production.
+
+## How the CI/CD works
+
+Each workflow ([deploy-dev.yml](../.github/workflows/deploy-dev.yml) /
+[deploy-prod.yml](../.github/workflows/deploy-prod.yml)) runs on push to its branch (only when
+`functions/**`, `firebase.json`, or `.firebaserc` change) and also supports **manual runs**
+(`workflow_dispatch`, from the Actions tab). Each job: checkout → Node 22 → `npm ci` → lint →
+write `functions/.env` from GitHub secrets → authenticate with a service-account key → `firebase
+deploy --only functions --project <alias> --non-interactive`.
+
+`functions/.env` is gitignored, so CI generates it fresh from secrets on every run — this mirrors
+how the 1st-gen functions read `process.env` locally today.
+
+## One-time setup (required before CI can deploy)
+
+### 1. Service accounts (one per project)
+In each Google Cloud project, create a service account for CI and grant roles:
+- **Cloud Functions Admin** (`roles/cloudfunctions.admin`)
+- **Service Account User** (`roles/iam.serviceAccountUser`)
+- **Artifact Registry Administrator** (`roles/artifactregistry.admin`)
+- **Cloud Build Editor** (`roles/cloudbuild.builds.editor`)
+
+Download a JSON key for each.
+
+### 2. GitHub repository secrets
+Settings → Secrets and variables → Actions → New repository secret:
+
+| Secret                       | Value                                             |
+| ---------------------------- | ------------------------------------------------- |
+| `DEV_FIREBASE_SA_KEY`        | DEV service-account JSON (whole file contents)    |
+| `PROD_FIREBASE_SA_KEY`       | PROD service-account JSON                         |
+| `DEV_STRIPE_SECRET`          | DEV Stripe secret (`sk_test_…`)                   |
+| `DEV_STRIPE_WEBHOOK_SECRET`  | DEV Stripe webhook signing secret                 |
+| `DEV_APPLE_SHARED_SECRET`    | DEV Apple shared secret                           |
+| `PROD_STRIPE_SECRET`         | PROD Stripe secret (`sk_live_…`)                  |
+| `PROD_STRIPE_WEBHOOK_SECRET` | PROD Stripe webhook signing secret                |
+| `PROD_APPLE_SHARED_SECRET`   | PROD Apple shared secret                          |
+
+(Take the DEV values from your local `functions/.env`; get PROD values from the Stripe live
+dashboard and App Store Connect.)
+
+### 3. Branch protection
+Settings → Branches → add rules for `main` and `development`:
+- Require a pull request before merging.
+- (Optional) Require the deploy workflow / a lint status check to pass.
+- Disallow direct pushes.
+
+## First PROD cutover — do this carefully (one time)
+
+Production currently runs old code that reads secrets via the deprecated `functions.config()`.
+`main`'s new code reads `process.env` (Node 22 + firebase-functions v7 / firebase-admin v13).
+The first promotion is therefore a real migration:
+
+1. **Confirm the `PROD_*` secrets are set** in GitHub (step 2). Without them the new code has no
+   Stripe/Apple credentials and payments break.
+2. **Do the first deploy in a controlled way**: run `deploy-prod.yml` manually
+   (`workflow_dispatch`) — or one manual CLI deploy — and validate *before* relying on the
+   merge trigger.
+3. **Smoke-test PROD** with the Postman collection ([gplay-dev.postman_collection.json](gplay-dev.postman_collection.json)),
+   setting `baseUrl` to `https://us-central1-g-play-dev-e4c4c.cloudfunctions.net`. `checkEmail`
+   returning `200` confirms admin/Firestore/secrets are wired.
+4. **Update the Stripe (live) webhook endpoint** to the PROD `stripeWebhook` URL and confirm
+   `PROD_STRIPE_WEBHOOK_SECRET` matches that endpoint's signing secret.
+5. **Coordinate with the `gplay_24` app** so production points at the PROD function URLs.
+
+## Manual fallback (if CI is unavailable)
+
+```bash
+nvm use                                            # Node 22 (.nvmrc)
+firebase deploy --only functions --project dev     # → DEV
+firebase deploy --only functions --project prod    # → PROD  (needs local functions/.env w/ prod values)
+```
+
+Always verify the target first with `firebase use`.


### PR DESCRIPTION
Establishes the environment-branch deployment model:
- development → DEV (g-play-dd31d), main → PROD (g-play-dev-e4c4c), auto-deployed on push via .github/workflows/deploy-{dev,prod}.yml (Node 22, npm ci, lint, .env from GitHub secrets, service-account auth, firebase deploy --only functions). Both also support manual workflow_dispatch (used for the controlled first PROD cutover).
- README.md: new "Estrategia de branches y despliegue" section; the old manual deploy section is reframed as the fallback.
- docs/DEPLOYMENT.md: deep reference — required secrets, service-account roles, branch protection, and the first-PROD cutover checklist (functions.config() → process.env migration, Stripe live webhook, app coordination).
- CLAUDE.md: note deploys are now CI/CD-driven.

Follow-up (not in this commit): create service accounts, add GitHub secrets, set branch protection, then consolidate main to development and delete the stale prod/production branches.