### PR TITLE
chore: trigger first CI deploy to DEV (smoke test)

### DIFF
--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.local
+# CI smoke test: trivial change under functions/ to trigger deploy-dev.yml


### PR DESCRIPTION
No-op change under `functions/` so the merge fires `.github/workflows/deploy-dev.yml` for the first time, now that the `DEV_*` repository secrets are configured.

Merging this = first automated deploy to DEV (`g-play-dd31d`). Watch it in the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)