### PR TITLE
docs: record verified CI service-account roles (7) + workflow_dispatch caveat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,11 @@ firebase functions:log                       # tail logs (npm run logs)
   [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md). Manual fallback (verify target with `firebase use`
   first): [.firebaserc](.firebaserc) aliases `default`/`dev` → DEV and `prod` → PROD, so
   `firebase deploy --only functions` hits DEV and `--project prod` hits PROD.
+  The DEV pipeline was **validated end-to-end on 2026-07-07**. The CI service account needs
+  the **seven** IAM roles in DEPLOYMENT.md §1 (the first four alone fail with 403s).
+  `workflow_dispatch` (manual run) only works once the workflow file exists on `main` —
+  until the first PROD cutover, trigger DEV deploys by merging a change touching
+  `functions/**`, or re-run a prior run with `gh run rerun <id>`.
 - Node runtime is pinned to **22** (`functions/package.json` engines + repo-root
   [.nvmrc](.nvmrc)) — the newest runtime Firebase-managed Cloud Functions supports (Node 24
   is *not* deployable here). No region is set, so functions deploy to the default
@@ -131,7 +136,12 @@ Added to `index.js`, all reusing the helpers/constants near the bottom of the fi
   `application_fee_amount = round(priceCents * TICKET_COMMISSION_RATE)` (rate is a TODO
   constant), idempotency key `` `${eventId}:${uid}` ``. Verified (`kyc==true`) callers only.
 - `stripeWebhook` (onRequest) — verifies `req.rawBody` against `STRIPE_WEBHOOK_SECRET`;
-  fulfills on `payment_intent.succeeded`. The **source of truth** for fulfillment.
+  fulfills on `payment_intent.succeeded`. The **source of truth** for fulfillment. A DEV
+  endpoint is registered in the Stripe **test** dashboard. Safe probes: an unsigned `POST`
+  returns `400 Webhook Error` (proves it's deployed and verifying), and the dashboard's
+  "Send test event" exercises the signed path — test events carry no `eventId`/`uid`
+  metadata, so the handler logs a warning and returns 200 without touching any data. Only
+  a real app purchase exercises the metadata-bearing fulfillment path.
 - `confirmTicketPurchase` (onCall) — client fallback; same idempotent fulfillment.
 - `fulfillTicketPurchase(eventId, uid)` — transaction-based idempotent join (guards on
   `usersPaid`); mirrors a free join, **no gToken deduction**.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -28,7 +28,10 @@ Rules:
 Each workflow ([deploy-dev.yml](../.github/workflows/deploy-dev.yml) /
 [deploy-prod.yml](../.github/workflows/deploy-prod.yml)) runs on push to its branch (only when
 `functions/**`, `firebase.json`, or `.firebaserc` change) and also supports **manual runs**
-(`workflow_dispatch`, from the Actions tab). Each job: checkout → Node 22 → `npm ci` → lint →
+(`workflow_dispatch`, from the Actions tab). *Caveat:* GitHub only lists a workflow for manual
+dispatch once its file exists on the **default branch** (`main`) — until the first
+`development` → `main` promotion, trigger the DEV deploy with a push (any PR merged into
+`development` touching `functions/**`), or re-run a previous run with `gh run rerun <id>`. Each job: checkout → Node 22 → `npm ci` → lint →
 write `functions/.env` from GitHub secrets → authenticate with a service-account key → `firebase
 deploy --only functions --project <alias> --non-interactive`.
 
@@ -38,11 +41,23 @@ how the 1st-gen functions read `process.env` locally today.
 ## One-time setup (required before CI can deploy)
 
 ### 1. Service accounts (one per project)
-In each Google Cloud project, create a service account for CI and grant roles:
+In each Google Cloud project, create a service account for CI (e.g. `github-deploy`) and grant
+it these roles **on the IAM page** (IAM & Admin → IAM — *not* the Service Accounts page, whose
+"Permissions" tab grants others access to the account instead):
 - **Cloud Functions Admin** (`roles/cloudfunctions.admin`)
 - **Service Account User** (`roles/iam.serviceAccountUser`)
 - **Artifact Registry Administrator** (`roles/artifactregistry.admin`)
 - **Cloud Build Editor** (`roles/cloudbuild.builds.editor`)
+- **Firebase Viewer** (`roles/firebase.viewer`) — the CLI reads the project's `adminSdkConfig`
+  before deploying; without it the deploy fails immediately with a 403
+- **Cloud Scheduler Admin** (`roles/cloudscheduler.admin`) — upserts the cron jobs behind
+  `pubsub.schedule(...)` functions; without it the 6 scheduled functions fail with
+  `cloudscheduler.jobs.update` 403s
+- **Pub/Sub Editor** (`roles/pubsub.editor`) — creates the topic that pairs with each *new*
+  scheduled function
+
+(This is the complete list verified against the first real DEV deploy on 2026-07-07 — the first
+four alone are not enough. IAM changes can take a minute or two to propagate before a rerun.)
 
 Download a JSON key for each.
 


### PR DESCRIPTION
Follow-up from today's CI validation: the runbook's 4 service-account roles were not enough. The first real DEV deploy needed 3 more — **Firebase Viewer** (adminSdkConfig read), **Cloud Scheduler Admin** (cron upserts for the 6 scheduled functions), **Pub/Sub Editor** (topics for new schedules). Also documents that `workflow_dispatch` is unavailable until the workflow file lands on `main`.

Docs only — merging will not trigger a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)